### PR TITLE
Fix wrong opcode in reverseFieldMap

### DIFF
--- a/src/main/kotlin/com/roscopeco/jasm/Modifiers.kt
+++ b/src/main/kotlin/com/roscopeco/jasm/Modifiers.kt
@@ -60,7 +60,7 @@ class Modifiers {
         Pair(Opcodes.ACC_PUBLIC, "public"),
         Pair(Opcodes.ACC_STATIC, "static"),
         Pair(Opcodes.ACC_FINAL, "final"),
-        Pair(Opcodes.ACC_TRANSIENT, "volatile"),
+        Pair(Opcodes.ACC_VOLATILE, "volatile"),
         Pair(Opcodes.ACC_TRANSIENT, "transient"),
         Pair(Opcodes.ACC_SYNTHETIC, "synthetic"),
     )


### PR DESCRIPTION
I was looking at how jasm is working and I saw this small bug that a wrong opcode was used in reverseFieldMap